### PR TITLE
Better error message on building failture

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -103,6 +103,8 @@ except SystemExit as e:
     error_message += "\n\nHint: search 'error' in current terminal session to find out the details. "
     error_message += "Here are some possible reasons that cause failure in building `cofi`:"
     error_message += "\n\t1. no Fortran compiler found -> install a Fortran compiler and ensure it's included in the path"
-    error_message += "\n"
+    error_message += "\n\n"
+    error_message += "If the error is not due to above reasons, please feel free to lodge an issue " \
+                     "at https://github.com/inlab-geo/cofi/issues for help\n"
     skbuild_error.args = (error_message,)
     sys.exit(skbuild_error)


### PR DESCRIPTION
Fixes #26 

I've suppressed part of the output but didn't manage suppress all (they are neither from Python stdout nor error traceback, so it's hard to block them from printing out). It would be helpful to find out the details if the failure is due to some reason we haven't encountered yet, so I assume having some output from `cmake` is a good thing.

Additionally, we add some hint to tell users how to find out the error cause and a list of possibilities.

<details>
    <summary>Here is a sample output (everything in the console) when no Fortran compiler is in the path</summary>
    
```
Processing /Users/jiawenhe/Documents/lab/cofi
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Preparing metadata (pyproject.toml): started
  Preparing metadata (pyproject.toml): finished with status 'done'
Requirement already satisfied: pyyaml>=6.0 in /usr/local/anaconda3/envs/cofi_dev/lib/python3.10/site-packages (from cofi==0.1.1.dev6) (6.0)
Requirement already satisfied: numpy>=1.20 in /usr/local/anaconda3/envs/cofi_dev/lib/python3.10/site-packages (from cofi==0.1.1.dev6) (1.22.3)
Requirement already satisfied: scipy>=1.0.0 in /usr/local/anaconda3/envs/cofi_dev/lib/python3.10/site-packages (from cofi==0.1.1.dev6) (1.8.0)
Building wheels for collected packages: cofi
  Building wheel for cofi (pyproject.toml): started
  Building wheel for cofi (pyproject.toml): finished with status 'error'
Failed to build cofi
  error: subprocess-exited-with-error
  
  × Building wheel for cofi (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [250 lines of output]
      Not searching for unused variables given on the command line.
      -- The C compiler identification is AppleClang 13.0.0.13000029
      -- Detecting C compiler ABI info
      -- Detecting C compiler ABI info - done
      -- Check for working C compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc - skipped
      -- Detecting C compile features
      -- Detecting C compile features - done
      -- The CXX compiler identification is AppleClang 13.0.0.13000029
      -- Detecting CXX compiler ABI info
      -- Detecting CXX compiler ABI info - done
      -- Check for working CXX compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ - skipped
      -- Detecting CXX compile features
      -- Detecting CXX compile features - done
      -- Configuring done
      -- Generating done
      -- Build files have been written to: /Users/jiawenhe/Documents/lab/cofi/_cmake_test_compile/build
      -- The C compiler identification is AppleClang 13.0.0.13000029
      -- The CXX compiler identification is AppleClang 13.0.0.13000029
      -- Detecting C compiler ABI info
      -- Detecting C compiler ABI info - done
      -- Check for working C compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc - skipped
      -- Detecting C compile features
      -- Detecting C compile features - done
      -- Detecting CXX compiler ABI info
      -- Detecting CXX compiler ABI info - done
      -- Check for working CXX compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ - skipped
      -- Detecting CXX compile features
      -- Detecting CXX compile features - done
      -- Found PythonInterp: /usr/local/anaconda3/envs/cofi_dev/bin/python3.10 (found version "3.10.4")
      -- Found PythonLibs: /usr/local/anaconda3/envs/cofi_dev/lib/libpython3.10.dylib (found version "3.10.4")
      -- Found Cython: /usr/local/anaconda3/envs/cofi_dev/bin/cython
      -- Found NumPy: /private/var/folders/90/6d5yfdt17_g1gy25611w80p40000gn/T/pip-build-env-2_z2c433/overlay/lib/python3.10/site-packages/numpy/core/include (found version "1.22.3")
      -- Found F2PY: /private/var/folders/90/6d5yfdt17_g1gy25611w80p40000gn/T/pip-build-env-2_z2c433/overlay/bin/f2py3 (found version "1.22.3")
      '/usr/local/anaconda3/envs/cofi_dev/bin/python3.10' '-c' 'import pybind11; print(pybind11.get_cmake_dir())'
      -- Found PythonLibs: /usr/local/anaconda3/envs/cofi_dev/lib/libpython3.10.dylib
      -- Performing Test HAS_FLTO
      -- Performing Test HAS_FLTO - Success
      -- Performing Test HAS_FLTO_THIN
      -- Performing Test HAS_FLTO_THIN - Success
      -- Found pybind11: /private/var/folders/90/6d5yfdt17_g1gy25611w80p40000gn/T/pip-build-env-2_z2c433/overlay/lib/python3.10/site-packages/pybind11/include (found version "2.9.2")
      -- Configuring done
      -- Generating done
      -- Build files have been written to: /Users/jiawenhe/Documents/lab/cofi/_skbuild/macosx-12.0-x86_64-3.10/cmake-build
      [1/4] Building C object CMakeFiles/_f2py_runtime_library.dir/private/var/folders/90/6d5yfdt17_g1gy25611w80p40000gn/T/pip-build-env-2_z2c433/overlay/lib/python3.10/site-packages/numpy/f2py/src/fortranobject.c.o
      In file included from /private/var/folders/90/6d5yfdt17_g1gy25611w80p40000gn/T/pip-build-env-2_z2c433/overlay/lib/python3.10/site-packages/numpy/f2py/src/fortranobject.c:2:
      In file included from /private/var/folders/90/6d5yfdt17_g1gy25611w80p40000gn/T/pip-build-env-2_z2c433/overlay/lib/python3.10/site-packages/numpy/f2py/src/fortranobject.h:13:
      In file included from /private/var/folders/90/6d5yfdt17_g1gy25611w80p40000gn/T/pip-build-env-2_z2c433/overlay/lib/python3.10/site-packages/numpy/core/include/numpy/arrayobject.h:5:
      In file included from /private/var/folders/90/6d5yfdt17_g1gy25611w80p40000gn/T/pip-build-env-2_z2c433/overlay/lib/python3.10/site-packages/numpy/core/include/numpy/ndarrayobject.h:12:
      In file included from /private/var/folders/90/6d5yfdt17_g1gy25611w80p40000gn/T/pip-build-env-2_z2c433/overlay/lib/python3.10/site-packages/numpy/core/include/numpy/ndarraytypes.h:1960:
      /private/var/folders/90/6d5yfdt17_g1gy25611w80p40000gn/T/pip-build-env-2_z2c433/overlay/lib/python3.10/site-packages/numpy/core/include/numpy/npy_1_7_deprecated_api.h:17:2: warning: "Using deprecated NumPy API, disable it with "          "#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION" [-W#warnings]
      #warning "Using deprecated NumPy API, disable it with " \
       ^
      1 warning generated.
      [2/4] Linking C static library lib_f2py_runtime_library.a
      [3/4] Generating _rfc.cpython-310-darwin.so
      FAILED: src/cofi/inv_problems/lib_rfc/_rfc.cpython-310-darwin.so /Users/jiawenhe/Documents/lab/cofi/_skbuild/macosx-12.0-x86_64-3.10/cmake-build/src/cofi/inv_problems/lib_rfc/_rfc.cpython-310-darwin.so
      cd /Users/jiawenhe/Documents/lab/cofi/_skbuild/macosx-12.0-x86_64-3.10/cmake-build/src/cofi/inv_problems/lib_rfc && /private/var/folders/90/6d5yfdt17_g1gy25611w80p40000gn/T/pip-build-env-2_z2c433/overlay/bin/f2py3 -m _rfc -c /Users/jiawenhe/Documents/lab/cofi/src/cofi/inv_problems/lib_rfc/RF.F90 /Users/jiawenhe/Documents/lab/cofi/src/cofi/inv_problems/lib_rfc/RFsubs/dpythag.f /Users/jiawenhe/Documents/lab/cofi/src/cofi/inv_problems/lib_rfc/RFsubs/dsvdcmp.f /Users/jiawenhe/Documents/lab/cofi/src/cofi/inv_problems/lib_rfc/RFsubs/four1.f /Users/jiawenhe/Documents/lab/cofi/src/cofi/inv_problems/lib_rfc/RFsubs/priorvalue.f90 /Users/jiawenhe/Documents/lab/cofi/src/cofi/inv_problems/lib_rfc/RFsubs/qlayer.f /Users/jiawenhe/Documents/lab/cofi/src/cofi/inv_problems/lib_rfc/RFsubs/ran3.f /Users/jiawenhe/Documents/lab/cofi/src/cofi/inv_problems/lib_rfc/RFsubs/svbksb.f /Users/jiawenhe/Documents/lab/cofi/src/cofi/inv_problems/lib_rfc/RFsubs/theo.f /Users/jiawenhe/Documents/lab/cofi/src/cofi/inv_problems/lib_rfc/RFsubs/theo_noise.f /Users/jiawenhe/Documents/lab/cofi/src/cofi/inv_problems/lib_rfc/RFsubs/voro2qmodel.f90 /Users/jiawenhe/Documents/lab/cofi/src/cofi/inv_problems/lib_rfc/RFsubs/whichcell.f90 --opt='-O3'
      running build
      running config_cc
      INFO: unifing config_cc, config, build_clib, build_ext, build commands --compiler options
      running config_fc
      INFO: unifing config_fc, config, build_clib, build_ext, build commands --fcompiler options
      running build_src
      INFO: build_src
      INFO: building extension "_rfc" sources
      INFO: f2py options: []
      INFO: f2py:> /var/folders/90/6d5yfdt17_g1gy25611w80p40000gn/T/tmp_ajrnubv/src.macosx-12.0-x86_64-3.10/_rfcmodule.c
      creating /var/folders/90/6d5yfdt17_g1gy25611w80p40000gn/T/tmp_ajrnubv/src.macosx-12.0-x86_64-3.10
      Reading fortran codes...
          Reading file '/Users/jiawenhe/Documents/lab/cofi/src/cofi/inv_problems/lib_rfc/RF.F90' (format:free)
      Line #13 in /Users/jiawenhe/Documents/lab/cofi/src/cofi/inv_problems/lib_rfc/RF.F90:"      INTENT(HIDE),DEPEND(voro) :: npt"
          analyzeline: cannot handle multiple attributes without type specification. Ignoring 'depend(voro)'.
      Line #138 in /Users/jiawenhe/Documents/lab/cofi/src/cofi/inv_problems/lib_rfc/RF.F90:"      INTENT(HIDE),DEPEND(voro) :: npt"
          analyzeline: cannot handle multiple attributes without type specification. Ignoring 'depend(voro)'.
      Line #246 in /Users/jiawenhe/Documents/lab/cofi/src/cofi/inv_problems/lib_rfc/RF.F90:"      INTENT(HIDE),DEPEND(voro) :: npt"
          analyzeline: cannot handle multiple attributes without type specification. Ignoring 'depend(voro)'.
          Reading file '/Users/jiawenhe/Documents/lab/cofi/src/cofi/inv_problems/lib_rfc/RFsubs/dpythag.f' (format:fix,strict)
          Reading file '/Users/jiawenhe/Documents/lab/cofi/src/cofi/inv_problems/lib_rfc/RFsubs/dsvdcmp.f' (format:fix,strict)
          Reading file '/Users/jiawenhe/Documents/lab/cofi/src/cofi/inv_problems/lib_rfc/RFsubs/four1.f' (format:fix,strict)
          Reading file '/Users/jiawenhe/Documents/lab/cofi/src/cofi/inv_problems/lib_rfc/RFsubs/priorvalue.f90' (format:free)
          Reading file '/Users/jiawenhe/Documents/lab/cofi/src/cofi/inv_problems/lib_rfc/RFsubs/qlayer.f' (format:fix,strict)
          Reading file '/Users/jiawenhe/Documents/lab/cofi/src/cofi/inv_problems/lib_rfc/RFsubs/rfi_param.inc' (format:fix)
          Reading file '/Users/jiawenhe/Documents/lab/cofi/src/cofi/inv_problems/lib_rfc/RFsubs/ran3.f' (format:fix,strict)
          Reading file '/Users/jiawenhe/Documents/lab/cofi/src/cofi/inv_problems/lib_rfc/RFsubs/svbksb.f' (format:fix,strict)
          Reading file '/Users/jiawenhe/Documents/lab/cofi/src/cofi/inv_problems/lib_rfc/RFsubs/theo.f' (format:fix,strict)
          Reading file '/Users/jiawenhe/Documents/lab/cofi/src/cofi/inv_problems/lib_rfc/RFsubs/rfi_param.inc' (format:fix)
          Reading file '/Users/jiawenhe/Documents/lab/cofi/src/cofi/inv_problems/lib_rfc/RFsubs/theo_noise.f' (format:fix,strict)
          Reading file '/Users/jiawenhe/Documents/lab/cofi/src/cofi/inv_problems/lib_rfc/RFsubs/rfi_param.inc' (format:fix)
          Reading file '/Users/jiawenhe/Documents/lab/cofi/src/cofi/inv_problems/lib_rfc/RFsubs/voro2qmodel.f90' (format:free)
          Reading file '/Users/jiawenhe/Documents/lab/cofi/src/cofi/inv_problems/lib_rfc/RFsubs/whichcell.f90' (format:free)
      Post-processing...
          Block: _rfc
                          Block: rfcalc_nonoise
                          Block: rfcalc_noise
                          Block: voro2mod
                          Block: dpythag
                          Block: dsvdcmp
                          Block: four1
                          Block: priorvalue
      {}
      In: :_rfc:/Users/jiawenhe/Documents/lab/cofi/src/cofi/inv_problems/lib_rfc/RFsubs/qlayer.f:qlayer
      vars2fortran: No typespec for argument "lc".
      {}
      In: :_rfc:/Users/jiawenhe/Documents/lab/cofi/src/cofi/inv_problems/lib_rfc/RFsubs/qlayer.f:qlayer
      vars2fortran: No typespec for argument "ang".
      {}
      In: :_rfc:/Users/jiawenhe/Documents/lab/cofi/src/cofi/inv_problems/lib_rfc/RFsubs/qlayer.f:qlayer
      vars2fortran: No typespec for argument "n".
                          Block: qlayer
      In: :_rfc:/Users/jiawenhe/Documents/lab/cofi/src/cofi/inv_problems/lib_rfc/RFsubs/qlayer.f:qlayer
      get_parameters[TODO]: implement evaluation of complex expression 1j
                          Block: ran3
                          Block: svbksb
      {}
      In: :_rfc:/Users/jiawenhe/Documents/lab/cofi/src/cofi/inv_problems/lib_rfc/RFsubs/theo.f:theo
      vars2fortran: No typespec for argument "n".
      {}
      In: :_rfc:/Users/jiawenhe/Documents/lab/cofi/src/cofi/inv_problems/lib_rfc/RFsubs/theo.f:theo
      vars2fortran: No typespec for argument "fs".
      {}
      In: :_rfc:/Users/jiawenhe/Documents/lab/cofi/src/cofi/inv_problems/lib_rfc/RFsubs/theo.f:theo
      vars2fortran: No typespec for argument "din".
      {}
      In: :_rfc:/Users/jiawenhe/Documents/lab/cofi/src/cofi/inv_problems/lib_rfc/RFsubs/theo.f:theo
      vars2fortran: No typespec for argument "a0".
      {}
      In: :_rfc:/Users/jiawenhe/Documents/lab/cofi/src/cofi/inv_problems/lib_rfc/RFsubs/theo.f:theo
      vars2fortran: No typespec for argument "c0".
      {}
      In: :_rfc:/Users/jiawenhe/Documents/lab/cofi/src/cofi/inv_problems/lib_rfc/RFsubs/theo.f:theo
      vars2fortran: No typespec for argument "t0".
      {}
      In: :_rfc:/Users/jiawenhe/Documents/lab/cofi/src/cofi/inv_problems/lib_rfc/RFsubs/theo.f:theo
      vars2fortran: No typespec for argument "nd".
                          Block: theo
      {}
      In: :_rfc:/Users/jiawenhe/Documents/lab/cofi/src/cofi/inv_problems/lib_rfc/RFsubs/theo_noise.f:theo_noise
      vars2fortran: No typespec for argument "n".
      {}
      In: :_rfc:/Users/jiawenhe/Documents/lab/cofi/src/cofi/inv_problems/lib_rfc/RFsubs/theo_noise.f:theo_noise
      vars2fortran: No typespec for argument "fs".
      {}
      In: :_rfc:/Users/jiawenhe/Documents/lab/cofi/src/cofi/inv_problems/lib_rfc/RFsubs/theo_noise.f:theo_noise
      vars2fortran: No typespec for argument "din".
      {}
      In: :_rfc:/Users/jiawenhe/Documents/lab/cofi/src/cofi/inv_problems/lib_rfc/RFsubs/theo_noise.f:theo_noise
      vars2fortran: No typespec for argument "a0".
      {}
      In: :_rfc:/Users/jiawenhe/Documents/lab/cofi/src/cofi/inv_problems/lib_rfc/RFsubs/theo_noise.f:theo_noise
      vars2fortran: No typespec for argument "c0".
      {}
      In: :_rfc:/Users/jiawenhe/Documents/lab/cofi/src/cofi/inv_problems/lib_rfc/RFsubs/theo_noise.f:theo_noise
      vars2fortran: No typespec for argument "t0".
      {}
      In: :_rfc:/Users/jiawenhe/Documents/lab/cofi/src/cofi/inv_problems/lib_rfc/RFsubs/theo_noise.f:theo_noise
      vars2fortran: No typespec for argument "nd".
      {}
      In: :_rfc:/Users/jiawenhe/Documents/lab/cofi/src/cofi/inv_problems/lib_rfc/RFsubs/theo_noise.f:theo_noise
      vars2fortran: No typespec for argument "sn".
                          Block: theo_noise
                          Block: voro2qmodel
                          Block: whichcell
      Post-processing (stage 2)...
      Building modules...
          Building module "_rfc"...
              Constructing wrapper function "rfcalc_nonoise"...
                time,wdata = rfcalc_nonoise(voro,mtype,fs,gauss_a,water_c,angle,time_shift,ndatar,v60)
              Constructing wrapper function "rfcalc_noise"...
                time,wdata = rfcalc_noise(voro,mtype,sn,fs,gauss_a,water_c,angle,time_shift,ndatar,v60,seed)
              Constructing wrapper function "voro2mod"...
                h,beta,vpvs,qa,qb = voro2mod(voro)
                  Creating wrapper for Fortran function "dpythag"("dpythag")...
              Constructing wrapper function "dpythag"...
                dpythag = dpythag(a,b)
              Constructing wrapper function "dsvdcmp"...
                dsvdcmp(a,m,n,w,v,[mp,np])
              Constructing wrapper function "four1"...
                four1(data,isign,[nn])
              Constructing wrapper function "priorvalue"...
                priorvalue(point,d_min,d_max,beta_min,beta_max,width,pv_min,pv_max)
              Constructing wrapper function "qlayer"...
                qlayer(lc,ang,n,h,valpha,vbeta,rho,qa,qb,rs,w,up,wp,usv,wsv,vsh)
                  Creating wrapper for Fortran function "ran3"("ran3")...
              Constructing wrapper function "ran3"...
                ran3 = ran3(idum)
              Constructing wrapper function "svbksb"...
                svbksb(u,w,v,m,n,b,x,[mp,np])
              Constructing wrapper function "theo"...
                theo(n,fbeta,h,vps,qa,qb,fs,din,a0,c0,t0,nd,rx)
              Constructing wrapper function "theo_noise"...
                theo_noise(n,fbeta,h,vps,qa,qb,fs,din,a0,c0,t0,nd,sn,rx)
              Constructing wrapper function "voro2qmodel"...
                voro2qmodel(voro,npt,d_min,d_max,beta,h,vpvs,qa,qb,[npt_max])
              Constructing wrapper function "whichcell"...
                whichcell(point,voro,npt,ind,[npt_max])
          Wrote C/API module "_rfc" to file "/var/folders/90/6d5yfdt17_g1gy25611w80p40000gn/T/tmp_ajrnubv/src.macosx-12.0-x86_64-3.10/_rfcmodule.c"
          Fortran 77 wrappers are saved to "/var/folders/90/6d5yfdt17_g1gy25611w80p40000gn/T/tmp_ajrnubv/src.macosx-12.0-x86_64-3.10/_rfc-f2pywrappers.f"
      INFO:   adding '/var/folders/90/6d5yfdt17_g1gy25611w80p40000gn/T/tmp_ajrnubv/src.macosx-12.0-x86_64-3.10/fortranobject.c' to sources.
      INFO:   adding '/var/folders/90/6d5yfdt17_g1gy25611w80p40000gn/T/tmp_ajrnubv/src.macosx-12.0-x86_64-3.10' to include_dirs.
      copying /private/var/folders/90/6d5yfdt17_g1gy25611w80p40000gn/T/pip-build-env-2_z2c433/overlay/lib/python3.10/site-packages/numpy/f2py/src/fortranobject.c -> /var/folders/90/6d5yfdt17_g1gy25611w80p40000gn/T/tmp_ajrnubv/src.macosx-12.0-x86_64-3.10
      copying /private/var/folders/90/6d5yfdt17_g1gy25611w80p40000gn/T/pip-build-env-2_z2c433/overlay/lib/python3.10/site-packages/numpy/f2py/src/fortranobject.h -> /var/folders/90/6d5yfdt17_g1gy25611w80p40000gn/T/tmp_ajrnubv/src.macosx-12.0-x86_64-3.10
      INFO:   adding '/var/folders/90/6d5yfdt17_g1gy25611w80p40000gn/T/tmp_ajrnubv/src.macosx-12.0-x86_64-3.10/_rfc-f2pywrappers.f' to sources.
      INFO: build_src: building npy-pkg config files
      /private/var/folders/90/6d5yfdt17_g1gy25611w80p40000gn/T/pip-build-env-2_z2c433/overlay/lib/python3.10/site-packages/setuptools/command/install.py:34: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
        warnings.warn(
      running build_ext
      INFO: customize UnixCCompiler
      INFO: customize UnixCCompiler using build_ext
      INFO: get_default_fcompiler: matching types: '['gnu95', 'nag', 'nagfor', 'absoft', 'ibm', 'intel', 'gnu', 'g95', 'pg']'
      INFO: customize Gnu95FCompiler
      WARN: Could not locate executable gfortran
      WARN: Could not locate executable f95
      INFO: customize NAGFCompiler
      INFO: customize NAGFORCompiler
      WARN: Could not locate executable nagfor
      INFO: customize AbsoftFCompiler
      WARN: Could not locate executable f90
      WARN: Could not locate executable f77
      INFO: customize IBMFCompiler
      WARN: Could not locate executable xlf90
      WARN: Could not locate executable xlf
      INFO: customize IntelFCompiler
      WARN: Could not locate executable ifort
      WARN: Could not locate executable ifc
      INFO: customize GnuFCompiler
      WARN: Could not locate executable g77
      INFO: customize G95FCompiler
      WARN: Could not locate executable g95
      INFO: customize PGroupFCompiler
      WARN: Could not locate executable pgfortran
      WARN: don't know how to compile Fortran code on platform 'posix'
      warning: build_ext: f77_compiler=None is not available.
      
      INFO: building '_rfc' extension
      error: extension '_rfc' has Fortran sources but no Fortran compiler found
      ninja: build stopped: subcommand failed.
      An error occurred while building with CMake.
        Command:
          cmake --build . --target install --config Release --
        Install target:
          install
        Source directory:
          /Users/jiawenhe/Documents/lab/cofi
        Working directory:
          /Users/jiawenhe/Documents/lab/cofi/_skbuild/macosx-12.0-x86_64-3.10/cmake-build
      Please check the install target is valid and see CMake's output for more information.
      
      Hint: search 'error' in current terminal session to find out the details. Here are some possible reasons that cause failure in building `cofi`:
          1. no Fortran compiler found -> install a Fortran compiler and ensure it's included in the path
      
      If the error is not due to above reasons, please feel free to lodge an issue at https://github.com/inlab-geo/cofi/issues for help

      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for cofi
ERROR: Could not build wheels for cofi, which is required to install pyproject.toml-based projects
```

</details>


