### PR TITLE
fix: readthedocs environment issue

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,8 +1,8 @@
 name: readthedocs
 dependencies:
-  - python=3.9
+  - python=3.10
   # - conda-forge::gfortran=11.2.0
-  - numpy>=1.22.2
+  - numpy>=1.20
   - scipy>=1.7.3
   - matplotlib>=3.5.0
   - pip>=21.2.4

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -2,8 +2,7 @@ name: readthedocs
 dependencies:
   - python=3.8
   # - conda-forge::gfortran=11.2.0
-  - numpy>=1.20
-  - scipy>=1.7.3
+  - scipy>=1.7.0
   - matplotlib>=3.5.0
   - pip
   - pip:

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,17 +1,17 @@
 name: readthedocs
 dependencies:
   - python=3.9
-  - conda-forge::gfortran=11.2.0
+  # - conda-forge::gfortran=11.2.0
   - numpy>=1.22.2
   - scipy>=1.7.3
   - matplotlib>=3.5.0
   - pip>=21.2.4
   - pip:
-    - sphinx-book-theme==0.2.0
+    - sphinx-book-theme==0.3.2
     - sphinx-panels==0.6.0
     - nbsphinx==0.8.8
-    - sphinx-togglebutton==0.3.0
-    - myst-nb==0.13.2
+    - sphinx-togglebutton==0.3.1
+    - myst-nb==0.14.0
     - sphinx-gallery==0.10.1
     - pypandoc==1.7.5
     - sphinxcontrib-mermaid==0.7.1

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,11 +1,11 @@
 name: readthedocs
 dependencies:
-  - python=3.10
+  - python=3.8
   # - conda-forge::gfortran=11.2.0
   - numpy>=1.20
   - scipy>=1.7.3
   - matplotlib>=3.5.0
-  - pip>=21.2.4
+  - pip
   - pip:
     - sphinx-book-theme==0.3.2
     - sphinx-panels==0.6.0

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,7 +1,7 @@
 name: readthedocs
 dependencies:
   - python=3.8
-  # - conda-forge::gfortran=11.2.0
+  - conda-forge::gfortran=11.2.0
   - scipy>=1.7.0
   - matplotlib>=3.5.0
   - pip


### PR DESCRIPTION
Due to unknown reasons, our mermaid graphs weren't processed starting this week. I fixed it by upgrading the version of `myst-nb` from 0.13.2 to 0.14.0. It's unknown why this issue didn't occur earlier.

Another confusion is that when I remove `conda-forge::gfortran=11.2.0` from environment.yml, the build fails due to failure to resolve the environment. I assume this to be some kind of bug in conda.